### PR TITLE
shell: bash for all whl installs in CIs

### DIFF
--- a/.github/workflows/CI-mac-m1.yml
+++ b/.github/workflows/CI-mac-m1.yml
@@ -58,6 +58,7 @@ jobs:
 
         - name: Install wheel
           run: pip install --find-links=${{github.workspace}} raidionicsseg
+          shell: bash
 
         - name: Test CLI
           run: raidionicsseg --help

--- a/.github/workflows/CI-mac-m1.yml
+++ b/.github/workflows/CI-mac-m1.yml
@@ -57,7 +57,7 @@ jobs:
             name: "Python wheel"
 
         - name: Install wheel
-          run: pip install --find-links=${{github.workspace}} raidionicsseg
+          run: pip install --find-links=${{github.workspace}} raidionicsseg-*
           shell: bash
 
         - name: Test CLI

--- a/.github/workflows/CI-mac.yml
+++ b/.github/workflows/CI-mac.yml
@@ -55,7 +55,7 @@ jobs:
             name: "Python wheel"
 
         - name: Install wheel
-          run: pip install --find-links=${{github.workspace}} raidionicsseg
+          run: pip install --find-links=${{github.workspace}} raidionicsseg-*
           shell: bash
 
         - name: Test CLI

--- a/.github/workflows/CI-mac.yml
+++ b/.github/workflows/CI-mac.yml
@@ -56,6 +56,7 @@ jobs:
 
         - name: Install wheel
           run: pip install --find-links=${{github.workspace}} raidionicsseg
+          shell: bash
 
         - name: Test CLI
           run: raidionicsseg --help

--- a/.github/workflows/CI-ubuntu.yml
+++ b/.github/workflows/CI-ubuntu.yml
@@ -55,7 +55,7 @@ jobs:
             name: "Python wheel"
 
         - name: Install wheel
-          run: pip install --find-links=${{github.workspace}} raidionicsseg
+          run: pip install --find-links=${{github.workspace}} raidionicsseg-*
           shell: bash
 
         - name: Test CLI

--- a/.github/workflows/CI-ubuntu.yml
+++ b/.github/workflows/CI-ubuntu.yml
@@ -56,6 +56,7 @@ jobs:
 
         - name: Install wheel
           run: pip install --find-links=${{github.workspace}} raidionicsseg
+          shell: bash
 
         - name: Test CLI
           run: raidionicsseg --help

--- a/.github/workflows/CI-windows.yml
+++ b/.github/workflows/CI-windows.yml
@@ -60,6 +60,7 @@ jobs:
 
         - name: Install wheel
           run: pip install --find-links=${{github.workspace}} raidionicsseg
+          shell: bash
 
         - name: Test CLI
           run: raidionicsseg --help

--- a/.github/workflows/CI-windows.yml
+++ b/.github/workflows/CI-windows.yml
@@ -59,7 +59,7 @@ jobs:
             name: "Python wheel"
 
         - name: Install wheel
-          run: pip install --find-links=. raidionicsseg
+          run: pip install --find-links=. raidionicsseg-*
           shell: bash
 
         - name: Test CLI

--- a/.github/workflows/CI-windows.yml
+++ b/.github/workflows/CI-windows.yml
@@ -59,7 +59,7 @@ jobs:
             name: "Python wheel"
 
         - name: Install wheel
-          run: pip install --find-links=${{github.workspace}} raidionicsseg
+          run: pip install --find-links=. raidionicsseg
           shell: bash
 
         - name: Test CLI


### PR DESCRIPTION
I observed an issue with installing compiled wheels in my test CIs in [another project](https://github.com/andreped/GradientAccumulator/blob/main/.github/workflows/test.yml#L82).

Apparently, `pip` disregards the `--file-links` argument if it finds a suitable wheel with the same name on PyPI.

This was solved by adding the `-*` wildcard fix like so `package_name-*` to the command. However, that fails in Powershell. Thus, forcing the command to run with `bash` works for all operating systems.